### PR TITLE
fix issue whereby www. does not work

### DIFF
--- a/sockets/redirection.js
+++ b/sockets/redirection.js
@@ -30,7 +30,7 @@ function handle(request, response) {
 				var time = data[1];
 				var site = redirectdata[0];
 				var redirect = redirectdata[1];
-				if(site === request.headers.host.toLowerCase()) {
+				if(site === request.headers.host.toLowerCase() || "www."+site === request.headers.host.toLowerCase()) {
 					found = true;
 					logger.log(".::[system runs on redirection mode]::.");
 					logger.log("client "+request.connection.remoteAddress+" visited "+request.headers.host+request.url+" and has been redirected to " + redirect);


### PR DESCRIPTION
This will fix the issue whereby the redirector works unresponsive.

when this rule is configurated inside the redirections.zone:
mysite.com->newsite.com;5

and as follows visit www.mysite.com, it will not redirect because www. makes the url for the redirector invalid.

this will solve the issue whereby www. gets detected aswell.
